### PR TITLE
[0.1.0] ID-05 프로젝트 초기 설정을 할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.github'
-version = '0.0.1-SNAPSHOT'
-description = 'ideantify-server'
+group = 'com.github.ideantify-server'
+version = '0.1.0'
 
 java {
     toolchain {
@@ -25,18 +24,15 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}

--- a/src/main/java/com/github/ideantifyserver/global/config/SwaggerConfig.java
+++ b/src/main/java/com/github/ideantifyserver/global/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.github.ideantifyserver.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        return new OpenAPI().components(new Components().addSecuritySchemes("JWT", securityScheme())).info(info());
+    }
+
+    private Info info() {
+
+        return new Info().
+                title("IDEANTIFY")
+                .description("아이디어 검증 플랫폼")
+                .version("0.0.0");
+    }
+
+    private SecurityScheme securityScheme() {
+
+        return new SecurityScheme().type(SecurityScheme.Type.HTTP).bearerFormat("JWT").scheme("bearer");
+    }
+
+
+
+}

--- a/src/main/java/com/github/ideantifyserver/global/exception/ApiException.java
+++ b/src/main/java/com/github/ideantifyserver/global/exception/ApiException.java
@@ -1,0 +1,21 @@
+package com.github.ideantifyserver.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException{
+
+    private final String code;
+
+    public ApiException(ApiExceptionCode code) {
+
+        super(code.getMessage());
+        this.code = code.getCode();
+    }
+
+    public ApiException(String code ,String message) {
+
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/github/ideantifyserver/global/exception/ApiExceptionCode.java
+++ b/src/main/java/com/github/ideantifyserver/global/exception/ApiExceptionCode.java
@@ -1,0 +1,13 @@
+package com.github.ideantifyserver.global.exception;
+
+public interface ApiExceptionCode {
+
+    String getCode();
+
+    String getMessage();
+
+    default ApiException toException() {
+
+        return new ApiException(this);
+    }
+}

--- a/src/main/java/com/github/ideantifyserver/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/github/ideantifyserver/global/exception/ApiExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.github.ideantifyserver.global.exception;
+
+import com.github.ideantifyserver.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ApiExceptionHandler {
+
+    @ExceptionHandler({ NoResourceFoundException.class, HttpRequestMethodNotSupportedException.class })
+    public ApiResponse<?> noResourceFoundException(Exception ignored) {
+
+        return ApiResponse.error("GLOBAL_001", "요청하신 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<?> httpMessageNotReadableException(HttpMessageNotReadableException ignored) {
+
+        return ApiResponse.error("GLOBAL_002", "요청 데이터가 올바르지 않습니다.");
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ApiResponse<?> authorizationDeniedException(AuthorizationDeniedException ignored) {
+
+        return ApiResponse.error("GLOBAL_003","권한이 없습니다.");
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        if (Objects.isNull(e.getBindingResult().getFieldError())) {
+
+            return ApiResponse.error("GLOBAL_004", e.getMessage());
+        }
+
+        String field = e.getBindingResult().getFieldError().getField();
+        String message = e.getBindingResult().getFieldError().getDefaultMessage();
+        String errorMessage = String.format("%s은(는) %s", field, message);
+
+        return ApiResponse.error("GLOBAL_005", errorMessage);
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse<?> apiException(ApiException e) {
+
+        return ApiResponse.error(e);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<?> exception(Exception e) {
+
+        log.error("", e);
+
+        return ApiResponse.error("GLOBAL_006", "알 수 없는 오류가 발생했습니다.");
+    }
+
+}

--- a/src/main/java/com/github/ideantifyserver/global/infra/mysql/BaseSchema.java
+++ b/src/main/java/com/github/ideantifyserver/global/infra/mysql/BaseSchema.java
@@ -1,0 +1,42 @@
+package com.github.ideantifyserver.global.infra.mysql;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access =  AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id")
+public abstract class BaseSchema {
+
+    @Id
+    @Column(nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+    @NotNull
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    UUID id;
+
+    @Column(nullable = false, updatable = false)
+    @NotNull
+    @CreatedDate
+    LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @NotNull
+    @LastModifiedDate
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/github/ideantifyserver/global/response/ApiResponse.java
+++ b/src/main/java/com/github/ideantifyserver/global/response/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.github.ideantifyserver.global.response;
+
+import com.github.ideantifyserver.global.exception.ApiException;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static ApiResponse<Void> ok() {
+
+        return new ApiResponse<>(true, null, null, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+
+        return new ApiResponse<>(true, null, null, data);
+    }
+
+    public static <T> ApiResponse<T> error(ApiException e) {
+
+        return error(e.getCode(), e.getMessage());
+    }
+
+    public static <T> ApiResponse<T> error(String code, String message) {
+
+        return new ApiResponse<>(false, code, message, null);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ideantify-server

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:ideantify}
+    username: ${MYSQL_USERNAME:root}
+    password: ${MYSQL_PASSWORD:root}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+  sql:
+    init:
+      mode: always


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Swagger/OpenAPI UI 도입 및 JWT 인증 스키마 추가로 API 문서/테스트 가능
  - 표준 API 응답 포맷 도입(성공/오류)과 오류 코드/메시지 제공
  - 전역 예외 처리로 일관된 오류 응답 반환

- 설정
  - MySQL 연결 및 JPA 설정을 application.yaml로 구성(환경변수 지원)
  - application.properties의 앱 이름 설정 제거

- 기타(Chores)
  - 빌드 좌표(group, version) 업데이트
  - OpenAPI UI, Lombok, MySQL 의존성 정리
  - 테스트 의존성 및 관련 설정 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->