### PR TITLE
[0.1.0] ID-20 keyword, userDomain 엔티티생성

### DIFF
--- a/src/main/java/com/github/ideantifyserver/domain/ideareport/entity/IdeaReportInput.java
+++ b/src/main/java/com/github/ideantifyserver/domain/ideareport/entity/IdeaReportInput.java
@@ -1,5 +1,7 @@
 package com.github.ideantifyserver.domain.ideareport.entity;
 
+import com.github.ideantifyserver.domain.keyword.entity.Keyword;
+import com.github.ideantifyserver.domain.user.entity.User;
 import com.github.ideantifyserver.global.infra.mysql.BaseSchema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/github/ideantifyserver/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/github/ideantifyserver/domain/keyword/entity/Keyword.java
@@ -1,0 +1,33 @@
+package com.github.ideantifyserver.domain.keyword.entity;
+
+import com.github.ideantifyserver.domain.ideareport.entity.IdeaReportInput;
+import com.github.ideantifyserver.domain.user.entity.UserDomain;
+import com.github.ideantifyserver.global.infra.mysql.BaseSchema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword extends BaseSchema {
+
+    @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    List<UserDomain> userDomains = new ArrayList<>();
+
+    @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    List<IdeaReportInput> ideaReportInputs = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    Keyword parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Keyword> children = new ArrayList<>();
+}

--- a/src/main/java/com/github/ideantifyserver/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/github/ideantifyserver/domain/keyword/entity/Keyword.java
@@ -29,5 +29,6 @@ public class Keyword extends BaseSchema {
     Keyword parent;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     List<Keyword> children = new ArrayList<>();
 }

--- a/src/main/java/com/github/ideantifyserver/domain/user/entity/UserDomain.java
+++ b/src/main/java/com/github/ideantifyserver/domain/user/entity/UserDomain.java
@@ -1,0 +1,24 @@
+package com.github.ideantifyserver.domain.user.entity;
+
+import com.github.ideantifyserver.domain.keyword.entity.Keyword;
+import com.github.ideantifyserver.global.infra.mysql.BaseSchema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDomain extends BaseSchema {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    Keyword keyword;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 백엔드에 키워드 엔터티와 사용자-키워드 연관 엔터티를 추가하고, 상하위 키워드 구조 및 관련 연관을 구성했습니다.
  - 아이디어 리포트 입력에서 키워드·사용자 타입 참조를 정리했습니다.
  - 지연 로딩과 삭제 전이 규칙을 적용해 데이터 일관성과 성능을 개선했습니다.
  - 본 변경은 내부 구조 개선으로, 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->